### PR TITLE
Fix bug in create_group; empty tag dict not allowed

### DIFF
--- a/src/stream.jl
+++ b/src/stream.jl
@@ -61,12 +61,17 @@ function create_group(
     config::AWSConfig,
     # this probably won't collide, most callers should add identifying information though
     log_group_name::AbstractString="julia-$(uuid4())";
-    tags::AbstractDict{<:AbstractString, <:AbstractString}=Dict{String, String}()
+    tags::AbstractDict{<:AbstractString, <:AbstractString}=Dict{String, String}(),
 )
-    tags = Dict{String, String}(tags)
-
-    aws_retry() do
-        create_log_group(config; logGroupName=log_group_name, tags=tags)
+    if isempty(tags)
+        aws_retry() do
+            create_log_group(config; logGroupName=log_group_name)
+        end
+    else
+        tags = Dict{String, String}(tags)
+        aws_retry() do
+            create_log_group(config; logGroupName=log_group_name, tags=tags)
+        end
     end
     return String(log_group_name)
 end

--- a/test/online.jl
+++ b/test/online.jl
@@ -3,7 +3,7 @@
 CI_USER_CFG = aws_config()
 # do not set this variable in CI; it should be versioned with the code
 # this is for locally overriding the stack used in testing
-TEST_STACK_NAME = get(ENV, "CLOUDWATCHLOGSJL_STACK_NAME", "CloudWatchLogs-jl-00014")
+TEST_STACK_NAME = get(ENV, "CLOUDWATCHLOGSJL_STACK_NAME", "CloudWatchLogs-jl-00015")
 TEST_RESOURCE_PREFIX = "pubci-$TEST_STACK_NAME-cwl-test"
 TEST_LOG_GROUP = "$TEST_RESOURCE_PREFIX-group"
 FORBIDDEN_LOG_GROUP = "$TEST_RESOURCE_PREFIX-group-forbidden"
@@ -38,6 +38,34 @@ end
     @testset "Named group" begin
         group_name = new_group("create_group")
         @test create_group(CFG, group_name; tags=Dict("Temporary"=>"true")) == group_name
+
+        response = CloudWatchLogsSDK.describe_log_groups(
+            CFG;
+            logGroupNamePrefix=group_name,
+            limit=1,
+        )
+
+        groups = response["logGroups"]
+
+        @test !isempty(groups)
+        @test groups[1]["logGroupName"] == group_name
+
+        delete_group(CFG, group_name)
+
+        response = CloudWatchLogsSDK.describe_log_groups(
+            CFG;
+            logGroupNamePrefix=group_name,
+            limit=1,
+        )
+
+        groups = response["logGroups"]
+
+        @test isempty(groups) || groups[1]["logGroupName"] != group_name
+    end
+
+    @testset "Named group no tags" begin
+        group_name = new_group("create_group_no_tags")
+        @test create_group(CFG, group_name) == group_name
 
         response = CloudWatchLogsSDK.describe_log_groups(
             CFG;


### PR DESCRIPTION
Previously if no tags were passed I would pass in an empty tag dict. Apparently AWS forbids that. Now we will not do that.