### PR TITLE
Add retries for all AWS operations and also retry MbedExceptions

### DIFF
--- a/src/CloudWatchLogs.jl
+++ b/src/CloudWatchLogs.jl
@@ -11,6 +11,7 @@ using AWSSDK.CloudWatchLogs:
     put_log_events
 using Compat: @__MODULE__, Nothing, AbstractDict
 using Compat.UUIDs
+using MbedTLS: MbedException
 using Memento
 using Mocking
 using TimeZones
@@ -35,8 +36,11 @@ const MAX_EVENT_SIZE = 262144
 const MAX_BATCH_LENGTH = 10000
 
 # 5 requests per second per log stream. This limit cannot be changed.
-const AWS_RATE_LIMIT = 0.2
-const AWS_DELAYS = ExponentialBackOff(n=10, first_delay=AWS_RATE_LIMIT, factor=1.1)
+const PUTLOGEVENTS_RATE_LIMIT = 0.2
+const PUTLOGEVENTS_DELAYS =
+    ExponentialBackOff(n=10, first_delay=PUTLOGEVENTS_RATE_LIMIT, factor=1.1)
+
+const GENERIC_AWS_DELAYS = ExponentialBackOff(n=10, first_delay=0.2, factor=2, jitter=0.2)
 
 __init__() = Memento.register(LOGGER)
 

--- a/src/handler.jl
+++ b/src/handler.jl
@@ -91,7 +91,7 @@ function process_logs!(handler::CloudWatchLogHandler)
         while isopen(handler.channel)  # might be able to avoid the error in this case
             wait(handler.channel)
             process_available_logs!(handler)
-            sleep(AWS_RATE_LIMIT)  # wait at least this long due to AWS rate limits
+            sleep(PUTLOGEVENTS_RATE_LIMIT)  # wait at least this long due to AWS rate limits
         end
     catch err
         if !(err isa InvalidStateException && err.state === :closed)

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -16,13 +16,7 @@ function aws_retry_cond(s, e)
     return (s, false)
 end
 
-function aws_retry(f)
-    wrapped = retry(delays=GENERIC_AWS_DELAYS, check=aws_retry_cond) do
-        f()
-    end
-
-    wrapped()
-end
+aws_retry(f) = retry(f, delays=GENERIC_AWS_DELAYS, check=aws_retry_cond)()
 
 struct CloudWatchLogStream
     config::AWSConfig

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -1,3 +1,29 @@
+const RETRYABLE_CODES = (
+    "IncompleteSignature",
+    "ThrottlingException",
+    "RequestExpired",
+)
+
+function aws_retry_cond(s, e)
+    if e isa AWSException && (500 <= e.cause.status <= 504 || e.code in RETRYABLE_CODES)
+        debug(LOGGER, "CloudWatchLogs operation encountered $(e.code); retrying")
+        return (s, true)
+    elseif e isa MbedException
+        debug(LOGGER, "CloudWatchLogs operation encountered $e; retrying")
+        return (s, true)
+    end
+
+    return (s, false)
+end
+
+function aws_retry(f)
+    wrapped = retry(delays=GENERIC_AWS_DELAYS, check=aws_retry_cond) do
+        f()
+    end
+
+    wrapped()
+end
+
 struct CloudWatchLogStream
     config::AWSConfig
     log_group_name::String
@@ -45,7 +71,9 @@ function create_group(
 )
     tags = Dict{String, String}(tags)
 
-    create_log_group(config; logGroupName=log_group_name, tags=tags)
+    aws_retry() do
+        create_log_group(config; logGroupName=log_group_name, tags=tags)
+    end
     return String(log_group_name)
 end
 
@@ -58,7 +86,9 @@ function delete_group(
     config::AWSConfig,
     log_group_name::AbstractString,
 )
-    delete_log_group(config; logGroupName=log_group_name)
+    aws_retry() do
+        delete_log_group(config; logGroupName=log_group_name)
+    end
     return nothing
 end
 
@@ -77,7 +107,13 @@ function create_stream(
     # this probably won't collide, most callers should add identifying information though
     log_stream_name::AbstractString="julia-$(uuid4())",
 )
-    create_log_stream(config; logGroupName=log_group_name, logStreamName=log_stream_name)
+    aws_retry() do
+        create_log_stream(
+            config;
+            logGroupName=log_group_name,
+            logStreamName=log_stream_name,
+        )
+    end
     return String(log_stream_name)
 end
 
@@ -91,7 +127,13 @@ function delete_stream(
     log_group_name::AbstractString,
     log_stream_name::AbstractString,
 )
-    delete_log_stream(config; logGroupName=log_group_name, logStreamName=log_stream_name)
+    aws_retry() do
+        delete_log_stream(
+            config;
+            logGroupName=log_group_name,
+            logStreamName=log_stream_name,
+        )
+    end
     return nothing
 end
 
@@ -120,13 +162,15 @@ function new_sequence_token(
     log_group::AbstractString,
     log_stream::AbstractString,
 )::Union{String, Nothing}
-    response = @mock describe_log_streams(
-        config;
-        logGroupName=log_group,
-        logStreamNamePrefix=log_stream,
-        orderBy="LogStreamName",  # orderBy and limit will ensure we get just the one
-        limit=1,                  # matching result
-    )
+    response = aws_retry() do
+        @mock describe_log_streams(
+            config;
+            logGroupName=log_group,
+            logStreamNamePrefix=log_stream,
+            orderBy="LogStreamName",  # orderBy and limit will ensure we get just the one
+            limit=1,                  # matching result
+        )
+    end
 
     streams = response["logStreams"]
 
@@ -224,8 +268,8 @@ function submit_logs(stream::CloudWatchLogStream, events::AbstractVector{LogEven
 
     function retry_cond(s, e)
         if e isa AWSException
-            if 500 <= e.cause.status <= 504
-                debug(LOGGER, sprint(io -> showerror(io, e)))
+            if 500 <= e.cause.status <= 504 || e.code == "ThrottlingException"
+                debug(LOGGER, "CloudWatchLogs PutLogEvents encountered $(e.code); retrying")
                 return (s, true)
             elseif e.cause.status == 400 && e.code == "InvalidSequenceTokenException"
                 debug(LOGGER) do
@@ -238,16 +282,16 @@ function submit_logs(stream::CloudWatchLogStream, events::AbstractVector{LogEven
                 update_sequence_token!(stream)
 
                 return (s, true)
-            elseif e.cause.status == 400 && e.code == "ThrottlingException"
-                debug(LOGGER, sprint(io -> showerror(io, e)))
-                return (s, true)
             end
+        elseif e isa MbedException
+            debug(LOGGER, "CloudWatchLogs PutLogEvents encountered $e; retrying")
+            return (s, true)
         end
 
         return (s, false)
     end
 
-    f = retry(delays=AWS_DELAYS, check=retry_cond) do
+    f = retry(delays=PUTLOGEVENTS_DELAYS, check=retry_cond) do
         @mock _put_log_events(stream, events)
     end
 

--- a/test/mocked_aws.jl
+++ b/test/mocked_aws.jl
@@ -81,7 +81,7 @@ end
         for c = 'a':'e'
             warn(logger, "$c")
         end
-        sleep(5 * CloudWatchLogs.AWS_RATE_LIMIT)  # probably max time we might have to wait
+        sleep(5 * CloudWatchLogs.PUTLOGEVENTS_RATE_LIMIT)  # probably max time we might have to wait
 
         messages = map(le -> le.message, logs)
         timestamps = map(le -> le.timestamp, logs)

--- a/test/online.jl
+++ b/test/online.jl
@@ -473,7 +473,7 @@ end
         end
 
         # wait for the logs to be submitted
-        for delay in CloudWatchLogs.AWS_DELAYS
+        for delay in CloudWatchLogs.PUTLOGEVENTS_DELAYS
             isready(handler.channel) || break
             sleep(delay)
         end


### PR DESCRIPTION
I tried to pick a decent retry scheme for the rest of the CloudWatchLogs operations. 