### PR TITLE
Remove deprecation in handler and fix throttle test

### DIFF
--- a/src/handler.jl
+++ b/src/handler.jl
@@ -110,7 +110,7 @@ function process_logs!(handler::CloudWatchLogHandler)
 end
 
 function Memento.emit(handler::CloudWatchLogHandler, record::Record)
-    dt = haskey(record, :date) ? record.:date : Dates.now(tz"UTC")
+    dt = isdefined(record, :date) ? record.date : Dates.now(tz"UTC")
     message = format(handler.fmt, record)
     event = LogEvent(message, dt)
     put!(handler.channel, event)

--- a/src/handler.jl
+++ b/src/handler.jl
@@ -110,7 +110,7 @@ function process_logs!(handler::CloudWatchLogHandler)
 end
 
 function Memento.emit(handler::CloudWatchLogHandler, record::Record)
-    dt = haskey(record, :date) ? record[:date] : Dates.now(tz"UTC")
+    dt = haskey(record, :date) ? record.:date : Dates.now(tz"UTC")
     message = format(handler.fmt, record)
     event = LogEvent(message, dt)
     put!(handler.channel, event)

--- a/test/mocked_aws.jl
+++ b/test/mocked_aws.jl
@@ -26,7 +26,9 @@ function throttle_patch()
     @patch function _put_log_events(stream::CloudWatchLogStream, events::AbstractVector{CloudWatchLogs.LogEvent})
         if first_time
             first_time = false
-            throw(AWSException("ThrottlingException", "", "", HTTP.ExceptionRequest.StatusError(400, "")))
+            response = HTTP.Messages.Response(400, "")
+            http_error = HTTP.ExceptionRequest.StatusError(400, "", "", response)
+            throw(AWSException("ThrottlingException", "", "", http_error))
         end 
         
         return Dict()


### PR DESCRIPTION
This fixes the following:

- A deprecation which appeared on production EIS:

```
┌ Warning: `getindex(rec::T, attr::Symbol) where T <: Record` is deprecated, use `getproperty(rec, attr)` instead.
│ caller = emit(::CloudWatchLogHandler{DefaultFormatter}, ::DefaultRecord) at handler.jl:113
└ @ CloudWatchLogs ~/.julia/packages/CloudWatchLogs/pOoZ5/src/handler.jl:113
```

- A failed throttle test due to an outdated HTTP.ExceptionRequest.StatusError constructor 
