### PR TITLE
Handle millisecond timestamps on 32-bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
+  - 1.2
   - nightly
 matrix:
   allow_failures:
@@ -17,6 +17,9 @@ after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 jobs:
   include:
+    - os: linux
+      arch: x86
+      julia: 1.2
     - stage: "Documentation"
       julia: 1.0
       script:

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 AWSCore = ">= 0.3.0"
 Memento = ">= 0.12.0"
-Mocking = ">= 0.5.3"
+Mocking = "0.7"
 TimeZones = ">= 0.5.0"
 julia = "0.7, 1.0"
 

--- a/src/event.jl
+++ b/src/event.jl
@@ -1,17 +1,17 @@
 """
-    unix_timestamp_ms(dt::Union{DateTime, ZonedDateTime}) -> Int
+    unix_timestamp_ms(dt::Union{DateTime, ZonedDateTime}) -> Int64
 
 Get a datetime's representation as a UNIX timestamp in milliseconds.
 `DateTime`s with no time zone are assumed to be in UTC.
 """
 function unix_timestamp_ms end
 
-unix_timestamp_ms(zdt::ZonedDateTime) = floor(Int, TimeZones.zdt2unix(zdt) * 1000)
+unix_timestamp_ms(zdt::ZonedDateTime) = floor(Int64, TimeZones.zdt2unix(zdt) * 1000)
 # assume UTC because you have to assume something
 unix_timestamp_ms(dt::DateTime) = unix_timestamp_ms(ZonedDateTime(dt, tz"UTC"))
 
 """
-    unix_timestamp_ms() -> Int
+    unix_timestamp_ms() -> Int64
 
 Get the current datetime's representation as a UNIX timestamp in milliseconds.
 """
@@ -25,7 +25,7 @@ Log event for submission to CloudWatch Logs.
 """
 struct LogEvent
     message::String
-    timestamp::Int
+    timestamp::Int64
 
     function LogEvent(message::AbstractString, timestamp::Real)
         message = String(message)

--- a/test/event.jl
+++ b/test/event.jl
@@ -1,7 +1,7 @@
 @testset "LogEvent" begin
 
 @testset "Timestamp" begin
-    time_in_ms = round(Int, time() * 1000)
+    time_in_ms = round(Int64, time() * 1000)
 
     event = LogEvent("Foo", time_in_ms)
     @test CloudWatchLogs.timestamp(event) == time_in_ms

--- a/test/mocked_aws.jl
+++ b/test/mocked_aws.jl
@@ -5,12 +5,12 @@
 CFG = AWSConfig()
 
 function dls_patch(output)
-    @patch function describe_log_streams(config; kwargs...)
+    @patch function CloudWatchLogs.describe_log_streams(config; kwargs...)
         output
     end
 end
 
-put_patch = @patch function _put_log_events(stream::CloudWatchLogStream, events::AbstractVector{CloudWatchLogs.LogEvent})
+put_patch = @patch function CloudWatchLogs._put_log_events(stream::CloudWatchLogStream, events::AbstractVector{CloudWatchLogs.LogEvent})
     return Dict("nextSequenceToken" => "3")
 end
 
@@ -23,18 +23,18 @@ end
 
 function throttle_patch()
     first_time = true
-    @patch function _put_log_events(stream::CloudWatchLogStream, events::AbstractVector{CloudWatchLogs.LogEvent})
+    @patch function CloudWatchLogs._put_log_events(stream::CloudWatchLogStream, events::AbstractVector{CloudWatchLogs.LogEvent})
         if first_time
             first_time = false
             response = HTTP.Messages.Response(400, "")
             http_error = HTTP.ExceptionRequest.StatusError(400, "", "", response)
             throw(AWSException("ThrottlingException", "", "", http_error))
-        end 
-        
+        end
+
         return Dict()
     end
 end
-            
+
 streams = [
     Dict(
         "storageBytes" => 1048576,
@@ -116,7 +116,7 @@ end
                 submit_log(stream, event)
             end
         end
-    end 
+    end
 end
 
 end

--- a/test/online.jl
+++ b/test/online.jl
@@ -225,7 +225,7 @@ end
 
         @test length(response["events"]) == 3
         messages = map(response["events"]) do event
-            @test round(Int, event["timestamp"]) in time_range
+            @test round(Int64, event["timestamp"]) in time_range
             event["message"]
         end
 
@@ -411,7 +411,7 @@ end
 
         @test length(response["events"]) == 2
         messages = map(response["events"]) do event
-            @test round(Int, event["timestamp"]) in time_range
+            @test round(Int64, event["timestamp"]) in time_range
             event["message"]
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,7 @@ function session_name()
     location = gethostname()
 
     name = "$user@$location"
-    ts = string(round(Int, time()))
+    ts = string(round(Int64, time()))
 
     # RoleSessionName must be no more than 64 characters
     max_name_length = 64 - length(ts) - 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Mocking
-Mocking.enable(; force=true)
+Mocking.activate()
 
 using CloudWatchLogs
 using CloudWatchLogs: MAX_EVENT_SIZE


### PR DESCRIPTION
`Int` is too small on 32-bit to store millisecond timestamps. Other uses of `Int` should be fine.

Fixes #15 