### PR TITLE
[repush] Add MbedTLS v1 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 AWSCore = "0.6"
-MbedTLS = "0.5, 0.6, 0.7"
+MbedTLS = "0.5, 0.6, 0.7, 1"
 Memento = "0.13, 1"
 Mocking = "0.7"
 TimeZones = "0.9, 0.10, 0.11, 1"


### PR DESCRIPTION
Repushed @curtd's https://github.com/invenia/CloudWatchLogs.jl/pull/24 in order to access env vars

We should set up bors here at some point.