### PR TITLE
Converted to use AWS.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.0"  # LTS
+          - "1.3"  # Minimal version of the package
           - "1"    # Latest Version
         os:
           - ubuntu-latest
@@ -31,9 +31,9 @@ jobs:
           - os: windows-latest
             arch: x86
         include:
-          # Add a 1.5 job because that's what Invenia actually uses
+          # Add a 1.6 job because that's what Invenia actually uses
           - os: ubuntu-latest
-            version: 1.5
+            version: 1.6
             arch: x64
     steps:
       - uses: actions/checkout@v2

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c4c1e6a2-6bdd-52e0-b56d-1d4734724d2d"
 version = "1.2.1"
 
 [deps]
-AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
+AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"
 Memento = "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9"
@@ -12,12 +12,12 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-AWSCore = "0.6"
-MbedTLS = "0.5, 0.6, 0.7, 1"
-Memento = "0.13, 1"
+AWS = "1"
+MbedTLS = "1"
+Memento = "1"
 Mocking = "0.7"
-TimeZones = "0.9, 0.10, 0.11, 1"
-julia = "1"
+TimeZones = "1"
+julia = "1.3"  # Minimum version for MbedTLS@1
 
 [extras]
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CloudWatchLogs"
 uuid = "c4c1e6a2-6bdd-52e0-b56d-1d4734724d2d"
-version = "1.2.1"
+version = "2.0.0"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/CloudWatchLogs.jl
+++ b/src/CloudWatchLogs.jl
@@ -1,8 +1,8 @@
 __precompile__()
 module CloudWatchLogs
 
-using AWSCore: AWSConfig, AWSException
-using AWSCore.Services: logs
+using AWS
+using AWS: AWSException
 using Dates
 using MbedTLS: MbedException
 using Memento
@@ -10,8 +10,10 @@ using Mocking
 using TimeZones
 using UUIDs
 
+@service CloudWatch_Logs
+
 export CloudWatchLogStream, LogEvent, submit_log, submit_logs
-export create_group, delete_group, create_stream, delete_stream
+export create_group, delete_group, create_stream, delete_stream, describe_log_streams
 export CloudWatchLogHandler
 export StreamNotFoundException, LogSubmissionException
 

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -65,12 +65,12 @@ function create_group(
 )
     if isempty(tags)
         aws_retry() do
-            logs(config, "CreateLogGroup"; logGroupName=log_group_name)
+            CloudWatch_Logs.create_log_group(log_group_name; aws_config=config)
         end
     else
         tags = Dict{String, String}(tags)
         aws_retry() do
-            logs(config, "CreateLogGroup"; logGroupName=log_group_name, tags=tags)
+            CloudWatch_Logs.create_log_group(log_group_name, Dict("tags"=>tags); aws_config=config)
         end
     end
     return String(log_group_name)
@@ -86,7 +86,7 @@ function delete_group(
     log_group_name::AbstractString,
 )
     aws_retry() do
-        logs(config, "DeleteLogGroup"; logGroupName=log_group_name)
+        CloudWatch_Logs.delete_log_group(log_group_name; aws_config=config)
     end
     return nothing
 end
@@ -107,12 +107,7 @@ function create_stream(
     log_stream_name::AbstractString="julia-$(uuid4())",
 )
     aws_retry() do
-        logs(
-            config,
-            "CreateLogStream";
-            logGroupName=log_group_name,
-            logStreamName=log_stream_name,
-        )
+        CloudWatch_Logs.create_log_stream(log_group_name, log_stream_name; aws_config=config)
     end
     return String(log_stream_name)
 end
@@ -128,12 +123,7 @@ function delete_stream(
     log_stream_name::AbstractString,
 )
     aws_retry() do
-        logs(
-            config,
-            "DeleteLogStream";
-            logGroupName=log_group_name,
-            logStreamName=log_stream_name,
-        )
+        CloudWatch_Logs.delete_log_stream(log_group_name, log_stream_name; aws_config=config)
     end
     return nothing
 end
@@ -149,7 +139,7 @@ function new_sequence_token(stream::CloudWatchLogStream)
     return new_sequence_token(stream.config, stream.log_group_name, stream.log_stream_name)
 end
 
-describe_log_streams(config; kwargs...) = logs(config, "DescribeLogStreams"; kwargs...)
+describe_log_streams(config::AWSConfig, log_group_name::AbstractString, params::AbstractDict) = CloudWatch_Logs.describe_log_streams(log_group_name, params; aws_config=config)
 
 """
     new_sequence_token(stream::CloudWatchLogStream) -> Union{String, Nothing}
@@ -167,11 +157,13 @@ function new_sequence_token(
 )::Union{String, Nothing}
     response = aws_retry() do
         @mock describe_log_streams(
-            config;
-            logGroupName=log_group,
-            logStreamNamePrefix=log_stream,
-            orderBy="LogStreamName",  # orderBy and limit will ensure we get just the one
-            limit=1,                  # matching result
+            config,
+            log_group,
+            Dict(
+                "logStreamNamePrefix" => log_stream,
+                "orderBy" => "LogStreamName",  # orderBy and limit will ensure we get just the one
+                "limit" => 1,  # matching result
+            ),
         )
     end
 
@@ -211,13 +203,12 @@ function update_sequence_token!(
 end
 
 function _put_log_events(stream::CloudWatchLogStream, events::AbstractVector{LogEvent})
-    logs(
-        stream.config,
-        "PutLogEvents";
-        logEvents=events,
-        logGroupName=stream.log_group_name,
-        logStreamName=stream.log_stream_name,
-        sequenceToken=sequence_token(stream),
+    CloudWatch_Logs.put_log_events(
+        events,
+        stream.log_group_name,
+        stream.log_stream_name,
+        Dict("sequenceToken" => sequence_token(stream));
+        aws_config=stream.config
     )
 end
 
@@ -296,7 +287,7 @@ function submit_logs(stream::CloudWatchLogStream, events::AbstractVector{LogEven
     end
 
     f = retry(delays=PUTLOGEVENTS_DELAYS, check=retry_cond) do
-        @mock _put_log_events(stream, events)
+        @mock CloudWatchLogs._put_log_events(stream, events)
     end
 
     min_valid_event = 1

--- a/test/mocked_aws.jl
+++ b/test/mocked_aws.jl
@@ -5,7 +5,7 @@
 CFG = AWSConfig()
 
 function dls_patch(output)
-    @patch function CloudWatchLogs.describe_log_streams(config; kwargs...)
+    @patch function CloudWatchLogs.describe_log_streams(config, log_group_name, params)
         output
     end
 end


### PR DESCRIPTION
## Overview

Needed to allow for internal packages to use `AWS.jl` as well. Note, this sets the new minimum version for this package to `Julia@1.3` to conform to `MbedTLS@1`.


## Note
There are more things to clean up here, however I wanted to keep this strictly to moving off of `AWSCore.jl`