### PR TITLE
Increase sleep time during logs tests

### DIFF
--- a/test/online.jl
+++ b/test/online.jl
@@ -452,7 +452,7 @@
                 sleep(delay)
             end
 
-            sleep(1)  # wait until AWS has injested the logs; this may or may not be enough
+            sleep(10)  # wait until AWS has injested the logs; this may or may not be enough
             response = CloudWatch_Logs.get_log_events(
                 TEST_LOG_GROUP, stream_name, Dict("startFromHead" => true, "limit" => 1)
             )

--- a/test/online.jl
+++ b/test/online.jl
@@ -461,7 +461,7 @@
             event = response["events"][1]
             @test event["message"] == "1"
 
-            sleep(5)  # wait until AWS has injested the logs; this may or may not be enough
+            sleep(10)  # wait until AWS has injested the logs; this may or may not be enough
             response = CloudWatch_Logs.get_log_events(
                 TEST_LOG_GROUP, stream_name, Dict("startFromHead" => false, "limit" => 1)
             )


### PR DESCRIPTION
These changes should hopefully fix [this](https://github.com/invenia/CloudWatchLogs.jl/issues/38) reoccurring CI test failure issue.