### PR TITLE
Bound Memento 1.x releases to pre-1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CloudWatchLogs"
 uuid = "c4c1e6a2-6bdd-52e0-b56d-1d4734724d2d"
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
@@ -14,7 +14,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 AWS = "1"
 MbedTLS = "1"
-Memento = "1"
+Memento = "1.0, 1.1, 1.2"
 Mocking = "0.7"
 TimeZones = "1"
 julia = "1.3"  # Minimum version for MbedTLS@1

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [compat]
 AWS = "1"
 MbedTLS = "1"
-Memento = "1.0, 1.1, 1.2"
+Memento = "~1.0, ~1.1, ~1.2"
 Mocking = "0.7"
 TimeZones = "1"
 julia = "1.3"  # Minimum version for MbedTLS@1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CloudWatchLogs"
 uuid = "c4c1e6a2-6bdd-52e0-b56d-1d4734724d2d"
-version = "2.0.1"
+version = "2.0.0"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"


### PR DESCRIPTION
Previously, Memento would store UTC ZonedDateTimes in the records and explicitly depended on TimeZones.jl. In 1.3, it switched to only storing `DateTime` in order to make TimeZones.jl an optional dependency. Since the rest of the Julia ecosystem defaults to `localzone` rather than UTC it made sense to update both packages to follow that same conventions.

https://github.com/invenia/Memento.jl/pull/182#issuecomment-965730317