### PR TITLE
Fix describe_log_streams error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CloudWatchLogs"
 uuid = "c4c1e6a2-6bdd-52e0-b56d-1d4734724d2d"
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/stream.jl
+++ b/src/stream.jl
@@ -134,7 +134,9 @@ end
 function describe_log_streams(
     config::AWSConfig, log_group_name::AbstractString, params::AbstractDict
 )
-    return CloudWatch_Logs.describe_log_streams(log_group_name, params; aws_config=config)
+    full_params = Dict("logGroupName" => log_group_name)
+    append!(full_params, params)
+    return CloudWatch_Logs.describe_log_streams(full_params; aws_config=config)
 end
 
 """


### PR DESCRIPTION
This PR fixes a MethodError when calling `describe_log_streams`.
This error is caused by a breakage in AWS.jl v1.82.0, which changed the signature of this function.
The new code should work with both AWS.jl<1.82.0 and >=1.82.0.

Fixes #48.
