### PR TITLE
Reduce tested CI platforms and increase minimum supported version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,26 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.3"  # Minimal version of the package
+          - "1.6"  # Minimal version of the package
           - "1"    # Latest Version
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
           - x86
-        exclude:
-          # Test 32-bit only on Linux
-          - os: macOS-latest
-            arch: x86
-          - os: windows-latest
-            arch: x86
-        include:
-          # Add a 1.6 job because that's what Invenia actually uses
-          - os: ubuntu-latest
-            version: 1.6
-            arch: x64
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,22 +49,6 @@ jobs:
         with:
           file: lcov.info
 
-  slack:
-    name: Notify Slack Failure
-    needs: test
-    runs-on: ubuntu-latest
-    if: always() && github.event_name == 'schedule'
-    steps:
-      - uses: technote-space/workflow-conclusion-action@v2
-      - uses: voxmedia/github-action-slack-notify-build@v1
-        if: env.WORKFLOW_CONCLUSION == 'failure'
-        with:
-          channel: nightly-dev
-          status: FAILED
-          color: danger
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.DEV_SLACK_BOT_TOKEN }}
-
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "CloudWatchLogs"
 uuid = "c4c1e6a2-6bdd-52e0-b56d-1d4734724d2d"
-version = "2.1.0"
+version = "2.2.0"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ MbedTLS = "1"
 Memento = "1"
 Mocking = "0.7"
 TimeZones = "1"
-julia = "1.3"  # Minimum version for MbedTLS@1
+julia = "1.6"  # LTS
 
 [extras]
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"


### PR DESCRIPTION
Bumps up to 1.6 and removes testing on macOS and Windows. 

Hopefully this means never having to debug this issue with 1.3: https://github.com/invenia/CloudWatchLogs.jl/actions/runs/4611313532/jobs/8150857804?pr=50